### PR TITLE
Fix for Jenkins build error.

### DIFF
--- a/src/main/java/com/cloudbees/maven/license/CompleterDelegate.java
+++ b/src/main/java/com/cloudbees/maven/license/CompleterDelegate.java
@@ -64,7 +64,7 @@ public class CompleterDelegate {
         List<License> actual = dependency.getLicenses();
         IllegalStateException error = new IllegalStateException("Expecting " + toString(expected) + " but found " + toString(actual) + " for dependency " + toString(dependency));
 
-        if (expected.size()!= actual.size())
+        if ((expected.size() != 0) && (expected.size()!= actual.size()))
             throw error;
 
         OUTER:


### PR DESCRIPTION
- Don't throw error, if an empty licence is expected, but the artifact already
  has a license attached.

When building latest jenkins, I get the following error:
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.cloudbees:maven-license-plugin:1.1:process (default) on project jenkins-core: Execution default of goal com.cloudbees:maven-license-plugin:1.1:process failed: java.lang.IllegalStateException: Expecting [] but found [Common Development and Distribution License (CDDL) v1.0] for dependency javax.mail:mail:1.4

This pull request fixes the above error.
