### PR TITLE
Prevent new high-priority SpotBugs violations from being introduced

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <maven-plugin-tools.version>3.9.0</maven-plugin-tools.version>
     <maven.version>3.8.1</maven.version>
     <!-- TODO fix violations -->
-    <spotbugs.skip>true</spotbugs.skip>
+    <spotbugs.threshold>High</spotbugs.threshold>
   </properties>
 
   <dependencies>

--- a/src/main/java/com/cloudbees/maven/license/CompleterDelegate.java
+++ b/src/main/java/com/cloudbees/maven/license/CompleterDelegate.java
@@ -4,7 +4,6 @@ import groovy.lang.Closure;
 import org.apache.maven.model.License;
 import org.apache.maven.project.MavenProject;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -89,20 +88,6 @@ public class CompleterDelegate {
         l.setName(name);
         l.setUrl(url);
         return l;
-    }
-
-    /**
-     * From the multi-licensed modules, accept one of them.
-     */
-    public void accept(String name) {
-        List<License> licenses = new ArrayList<>(dependency.getLicenses());
-        for (License lic : licenses) {
-            if (lic.getName().equals(name)) {
-                dependency.setLicenses(Collections.singletonList(lic));
-                return;
-            }
-        }
-        IllegalStateException error = new IllegalStateException("Expecting " + name + " but found " + toString(licenses) + " for dependency " + toString(dependency));
     }
 
     private String toString(Collection<License> lics) {


### PR DESCRIPTION
The only existing violation was dead code introduced in commit aad8a0f18119b38d7347689502e1511a4d92b646 and seemingly never used.