### PR TITLE
Update groovy-xml from 4.0.19 to 4.0.20 for Java 22 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-xml</artifactId>
-      <version>4.0.19</version>
+      <version>4.0.20</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
The change proposed updates `groovy-xml` from 4.0.19 to 4.0.20 to ensure plugins and core make it through `mvn clean verify package` when building with Java 22 without failing on the license stage, due to outdated asm.